### PR TITLE
feat: Lineup changes / live formations in LiveMatch page

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -49,6 +49,7 @@ model User {
   viewer_links_deleted viewer_links[] @relation("ViewerLinkDeletedBy")
   default_lineups_created default_lineups[] @relation("DefaultLineupCreatedBy")
   default_lineups_deleted default_lineups[] @relation("DefaultLineupDeletedBy")
+  live_formations_created live_formations[] @relation("LiveFormationCreatedBy")
 
   @@map("users")
   @@schema("grassroots")
@@ -130,6 +131,7 @@ model Match {
   match_state        match_state?
   match_periods      match_periods[]
   viewer_links       viewer_links[]
+  live_formations    live_formations[] @relation("LiveFormationMatch")
   awayTeam           Team           @relation("AwayTeam", fields: [away_team_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   created_by         User           @relation("MatchCreatedBy", fields: [created_by_user_id], references: [id])
   deleted_by         User?          @relation("MatchDeletedBy", fields: [deleted_by_user_id], references: [id])
@@ -399,6 +401,25 @@ model position_zones {
   @@schema("grassroots")
 }
 
+/// Live formation snapshots per match with start/end minutes and formation JSON
+model live_formations {
+  id                   String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  match_id             String   @db.Uuid
+  start_min            Decimal  @db.Decimal(5,2)
+  end_min              Decimal? @db.Decimal(5,2)
+  formation_data       Json
+  substitution_reason  String?  @db.VarChar(100)
+  created_at           DateTime @default(now()) @db.Timestamptz(6)
+  created_by_user_id   String   @db.Uuid
+
+  matches              Match    @relation("LiveFormationMatch", fields: [match_id], references: [match_id], onDelete: Cascade, onUpdate: NoAction)
+  created_by           User     @relation("LiveFormationCreatedBy", fields: [created_by_user_id], references: [id])
+
+  @@unique([match_id, start_min])
+  @@map("live_formations")
+  @@schema("grassroots")
+}
+
 enum UserRole {
   ADMIN
   USER
@@ -458,6 +479,7 @@ enum event_kind {
   free_kick
   ball_out
   own_goal
+  formation_change
 
   @@schema("grassroots")
 }

--- a/backend/scripts/sql/update_position_zones_from_frontend.sql
+++ b/backend/scripts/sql/update_position_zones_from_frontend.sql
@@ -1,0 +1,54 @@
+-- Update position_zones to match frontend formationCore.ts ZONES
+-- Safe to run repeatedly. This truncates the table and re-inserts canonical zones.
+-- Schema: grassroots.position_zones (position_code enum must include all codes used below)
+
+BEGIN;
+
+-- Clear existing zones (adjust if you prefer a softer update strategy)
+TRUNCATE TABLE grassroots.position_zones RESTART IDENTITY;
+
+-- GK
+INSERT INTO grassroots.position_zones (position_code, zone_name, min_x, max_x, min_y, max_y, priority)
+VALUES ('GK', 'Goalkeeper', 0, 12, 40, 60, 1);
+
+-- Defenders
+INSERT INTO grassroots.position_zones VALUES ('CB',  'Center Back',      12, 32, 28, 72, 2);
+INSERT INTO grassroots.position_zones VALUES ('LB',  'Left Back',         8, 28,  0, 36, 2);
+INSERT INTO grassroots.position_zones VALUES ('RB',  'Right Back',        8, 28, 64,100, 2);
+INSERT INTO grassroots.position_zones VALUES ('LWB', 'Left Wing Back',   24, 42,  0, 32, 2);
+INSERT INTO grassroots.position_zones VALUES ('RWB', 'Right Wing Back',  24, 42, 68,100, 2);
+INSERT INTO grassroots.position_zones VALUES ('WB',  'Wing Back',        24, 42, 20, 80, 1);
+INSERT INTO grassroots.position_zones VALUES ('FB',  'Full Back',        12, 32, 20, 80, 1);
+
+-- Midfield (DM/CM/AM bands)
+INSERT INTO grassroots.position_zones VALUES ('CDM', 'Defensive Midfielder', 34, 52, 30, 70, 3);
+INSERT INTO grassroots.position_zones VALUES ('DM',  'Defensive Midfielder', 34, 52, 30, 70, 1);
+INSERT INTO grassroots.position_zones VALUES ('CM',  'Central Midfielder',   54, 58, 24, 76, 3);
+INSERT INTO grassroots.position_zones VALUES ('LCM', 'Left CM',              50, 56, 24, 50, 1);
+INSERT INTO grassroots.position_zones VALUES ('RCM', 'Right CM',             50, 56, 50, 76, 1);
+INSERT INTO grassroots.position_zones VALUES ('CAM', 'Attacking Midfielder', 60, 66, 30, 70, 3);
+INSERT INTO grassroots.position_zones VALUES ('LAM', 'Left Attacking Mid',   60, 68,  8, 36, 2);
+INSERT INTO grassroots.position_zones VALUES ('RAM', 'Right Attacking Mid',  60, 68, 64, 92, 2);
+INSERT INTO grassroots.position_zones VALUES ('AM',  'Attacking Midfielder', 60, 68, 24, 76, 1);
+INSERT INTO grassroots.position_zones VALUES ('LM',  'Left Midfielder',      40, 62,  0, 30, 3);
+INSERT INTO grassroots.position_zones VALUES ('RM',  'Right Midfielder',     40, 62, 70,100, 3);
+INSERT INTO grassroots.position_zones VALUES ('WM',  'Wide Midfielder',      40, 62, 20, 80, 1);
+
+-- Forwards / Wingers
+INSERT INTO grassroots.position_zones VALUES ('LW',  'Left Winger',         76, 98,  0, 36, 4);
+INSERT INTO grassroots.position_zones VALUES ('RW',  'Right Winger',        76, 98, 64,100, 4);
+INSERT INTO grassroots.position_zones VALUES ('CF',  'Centre Forward',      72, 96, 30, 70, 4);
+INSERT INTO grassroots.position_zones VALUES ('ST',  'Striker',             82,100, 24, 76, 4);
+INSERT INTO grassroots.position_zones VALUES ('SS',  'Second Striker',      70, 90, 30, 70, 2);
+INSERT INTO grassroots.position_zones VALUES ('LF',  'Left Forward',        80, 98,  0, 40, 2);
+INSERT INTO grassroots.position_zones VALUES ('RF',  'Right Forward',       80, 98, 60,100, 2);
+
+COMMIT;
+
+-- How to run (examples):
+-- 1) psql:
+--    psql "$DATABASE_URL" -f backend/scripts/sql/update_position_zones_from_frontend.sql
+-- 2) Docker Postgres
+--    docker exec -i <pg-container> psql -U <user> -d <db> -f /work/backend/scripts/sql/update_position_zones_from_frontend.sql
+-- After running, restart backend or wait 5 minutes for cache expiry.
+

--- a/backend/src/services/EventService.ts
+++ b/backend/src/services/EventService.ts
@@ -274,6 +274,7 @@ export class EventService {
         periodNumber: transformed.periodNumber || null,
         clockMs: transformed.clockMs || 0,
         sentiment: transformed.sentiment || 0,
+        notes: transformed.notes || null,
         createdAt: transformed.createdAt,
       }});
     } catch {}

--- a/backend/src/services/LiveFormationService.ts
+++ b/backend/src/services/LiveFormationService.ts
@@ -1,0 +1,304 @@
+import { PrismaClient, Prisma } from '@prisma/client';
+import { withPrismaErrorHandling } from '../utils/prismaErrorHandler';
+import { LineupService } from './LineupService';
+import { PositionCalculatorService } from './PositionCalculatorService';
+
+export type FormationData = {
+  players: Array<{
+    id: string;
+    name: string;
+    squadNumber?: number | null;
+    preferredPosition?: string | null;
+    position: { x: number; y: number };
+  }>;
+};
+
+export class LiveFormationService {
+  private prisma: PrismaClient;
+  private lineupService: LineupService;
+  private positionCalc: PositionCalculatorService;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+    this.lineupService = new LineupService();
+    this.positionCalc = new PositionCalculatorService();
+  }
+
+  async getCurrentFormation(matchId: string, userId: string, userRole: string): Promise<FormationData | null> {
+    // Authorization via match ownership
+    const matchWhere: any = { match_id: matchId, is_deleted: false };
+    if (userRole !== 'ADMIN') matchWhere.created_by_user_id = userId;
+    const match = await this.prisma.match.findFirst({ where: matchWhere });
+    if (!match) return null;
+
+    // Prefer live_formations active snapshot
+    const active = await this.prisma.live_formations.findFirst({
+      where: { match_id: matchId, end_min: null },
+      orderBy: [{ start_min: 'desc' }]
+    });
+    if (active) {
+      // Trust stored snapshot
+      const data = (active.formation_data || {}) as FormationData;
+      if (data && Array.isArray((data as any).players)) return data;
+    }
+
+    // Fallback: derive from current lineup at time now (assume 0 if no state)
+    const nowMinutes = 0;
+    const current = await this.lineupService.getCurrentLineup(matchId, nowMinutes, userId, userRole);
+    if (!current || current.length === 0) return { players: [] };
+    const players = current.map(lu => ({
+      id: lu.player.id,
+      name: lu.player.name,
+      squadNumber: lu.player.squadNumber,
+      preferredPosition: lu.player.preferredPosition || undefined,
+      position: {
+        x: (lu as any).pitchX ?? 0,
+        y: (lu as any).pitchY ?? 0,
+      }
+    }));
+    return { players };
+  }
+
+  async applyFormationChange(params: {
+    matchId: string;
+    startMin: number; // current minute
+    formation: FormationData;
+    userId: string;
+    userRole: string;
+    reason?: string | null;
+  }): Promise<{
+    liveFormationId: string;
+    substitutions: Array<{ out?: { id: string; name?: string | null }; in?: { id: string; name?: string | null } }>;
+  }> {
+    return withPrismaErrorHandling(async () => {
+      console.log('[LiveFormationService] applyFormationChange:start', params.matchId, params.startMin, params.reason);
+      const { matchId, startMin, formation, userId, userRole, reason } = params;
+
+      // Authorization via match ownership
+      const matchWhere: any = { match_id: matchId, is_deleted: false };
+      if (userRole !== 'ADMIN') matchWhere.created_by_user_id = userId;
+      const match = await this.prisma.match.findFirst({ where: matchWhere });
+      if (!match) {
+        const error = new Error('Match not found or access denied');
+        (error as any).code = 'MATCH_ACCESS_DENIED';
+        (error as any).statusCode = 403;
+        throw error;
+      }
+
+      // Capture current active lineup players to compute substitutions
+      const currentActive = await this.prisma.lineup.findMany({
+        where: { match_id: matchId, is_deleted: false, end_min: null },
+        include: { players: { select: { id: true, name: true } } }
+      });
+      const currentSet = new Set(currentActive.map(l => l.player_id));
+      const nextSet = new Set(formation.players.map(p => p.id));
+      const outs = [...currentSet].filter(id => !nextSet.has(id));
+      const ins = [...nextSet].filter(id => !currentSet.has(id));
+
+      // Prepare substitutions summary (best-effort pairing) upfront
+      const subs: Array<{ out?: { id: string; name?: string | null }; in?: { id: string; name?: string | null } }> = [];
+      const outPlayers = outs.map(id => ({ id, name: currentActive.find(l => l.player_id === id)?.players.name || null }));
+      const inPlayers = ins.map(id => ({ id, name: formation.players.find(p => p.id === id)?.name || null }));
+      const maxPairs = Math.max(outPlayers.length, inPlayers.length);
+      for (let i = 0; i < maxPairs; i++) {
+        subs.push({ out: outPlayers[i], in: inPlayers[i] });
+      }
+
+      // Transaction: end active snapshot and lineups, create new snapshot and lineups
+      const result = await this.prisma.$transaction(async (tx) => {
+        // Capture current active formation snapshot (if any) for timeline
+        const activeBefore = await tx.live_formations.findFirst({
+          where: { match_id: matchId, end_min: null },
+          orderBy: [{ start_min: 'desc' }]
+        });
+        // Resolve a unique start minute (avoid UNIQUE(match_id,start_min) collisions)
+        let start = new Prisma.Decimal(startMin as any);
+        const existsAtMinute = async (s: Prisma.Decimal) => {
+          const found = await tx.live_formations.findFirst({ where: { match_id: matchId, start_min: s } });
+          return !!found;
+        };
+        let guard = 0;
+        while (await existsAtMinute(start) && guard < 100) {
+          // Add 0.01 minute (~0.6s) until free (DECIMAL(5,2) precision)
+          start = new Prisma.Decimal((Number(start) + 0.01).toFixed(2));
+          guard++;
+        }
+        // End current live formation if exists
+        const existing = await tx.live_formations.findFirst({
+          where: { match_id: matchId, end_min: null },
+          orderBy: [{ start_min: 'desc' }]
+        });
+        if (existing) {
+          await tx.live_formations.update({
+            where: { id: existing.id },
+            data: { end_min: start, substitution_reason: reason || existing.substitution_reason || undefined }
+          });
+        }
+
+        // Create new live formation
+        const created = await tx.live_formations.create({
+          data: {
+            match_id: matchId,
+            start_min: start as any,
+            formation_data: formation as any,
+            substitution_reason: reason || null,
+            created_by_user_id: userId
+          }
+        });
+
+        // End current lineup rows
+        await tx.lineup.updateMany({
+          where: { match_id: matchId, end_min: null, is_deleted: false },
+          data: { end_min: Number(start), updated_at: new Date(), substitution_reason: reason || undefined }
+        });
+
+        // Create new lineup rows from formation
+        // Also gather line-group counts to build formation label
+        let def = 0, dm = 0, cm = 0, am = 0, fwd = 0, gk = 0;
+        for (const p of formation.players) {
+          // Compute position code from pitch coordinates
+          const calc = await this.positionCalc.calculatePosition(p.position.x, p.position.y);
+          const posCode = calc?.position || 'SUB';
+          const code = String(posCode).toUpperCase();
+          if (code === 'GK') gk++; else if (['CB','LCB','RCB','SW','LB','RB','LWB','RWB','WB','FB'].includes(code)) def++;
+          else if (['CDM','LDM','RDM','DM'].includes(code)) dm++;
+          else if (['CM','LCM','RCM','LM','RM','WM'].includes(code)) cm++;
+          else if (['CAM','LAM','RAM','AM'].includes(code)) am++;
+          else fwd++;
+          await tx.lineup.create({
+            data: {
+              match_id: matchId,
+              player_id: p.id,
+              start_min: Number(start),
+              end_min: null,
+              position: posCode as any,
+              pitch_x: new Prisma.Decimal(p.position.x as any) as any,
+              pitch_y: new Prisma.Decimal(p.position.y as any) as any,
+              substitution_reason: reason || null,
+              created_by_user_id: userId
+            }
+          });
+        }
+
+        const toLabel = (() => {
+          // Ignore GK in outfield label
+          const hasAM = am > 0;
+          if (hasAM) {
+            const vec = [def, dm + cm, am, fwd].filter(n => n > 0);
+            return vec.join('-');
+          } else {
+            const vec = [def, dm + cm + am, fwd].filter(n => n > 0);
+            return vec.join('-');
+          }
+        })();
+
+        // Persist a formation_change event for timeline persistence
+        try {
+          const activePeriod = await tx.match_periods.findFirst({
+            where: { match_id: matchId, started_at: { not: null }, ended_at: null, is_deleted: false },
+            select: { period_number: true, period_type: true }
+          });
+          // Build previous label from previous snapshot (if any)
+          const fromLabel = await (async () => {
+            if (!activeBefore?.formation_data || !Array.isArray((activeBefore as any).formation_data?.players)) return null;
+            let d=0,m=0,c=0,a=0,f=0,g=0;
+            const prevPlayers = ((activeBefore as any).formation_data.players as any[]);
+            for (const pl of prevPlayers) {
+              try {
+                const calcPrev = await this.positionCalc.calculatePosition(Number(pl.position?.x || 0), Number(pl.position?.y || 0));
+                const code = String(calcPrev?.position || 'SUB').toUpperCase();
+                if (code === 'GK') g++; else if (['CB','LCB','RCB','SW','LB','RB','LWB','RWB','WB','FB'].includes(code)) d++;
+                else if (['CDM','LDM','RDM','DM'].includes(code)) m++;
+                else if (['CM','LCM','RCM','LM','RM','WM'].includes(code)) c++;
+                else if (['CAM','LAM','RAM','AM'].includes(code)) a++;
+                else f++;
+              } catch {}
+            }
+            const hasAM = a > 0;
+            if (hasAM) return [d, m + c, a, f].filter(n => n > 0).join('-');
+            return [d, m + c + a, f].filter(n => n > 0).join('-');
+          })();
+
+          // Persist richer details in notes as JSON for timeline rendering
+          const notesPayload = {
+            reason: reason || null,
+            formationFrom: fromLabel,
+            formationTo: toLabel,
+            substitutions: subs.map(s => ({
+              out: s.out ? { id: s.out.id, name: s.out.name || null } : null,
+              in: s.in ? { id: s.in.id, name: s.in.name || null } : null,
+            })),
+            formation: { players: formation.players },
+          };
+          const event = await tx.event.create({
+            data: {
+              match_id: matchId,
+              kind: 'formation_change' as any,
+              period_number: activePeriod?.period_number || null,
+              clock_ms: Math.round(Number(start) * 60000),
+              notes: JSON.stringify(notesPayload),
+              created_by_user_id: userId,
+            }
+          });
+          console.log('[LiveFormationService] formation_change event persisted', event.id);
+          // Also broadcast via SSE like a normal event for coach/viewers listening to event_created
+          try {
+            const { sseHub } = await import('../utils/sse');
+            sseHub.broadcast(matchId, 'event_created', { event: {
+              id: event.id,
+              kind: 'formation_change',
+              teamId: null,
+              teamName: undefined,
+              playerId: null,
+              playerName: undefined,
+              periodType: activePeriod?.period_type,
+              periodNumber: activePeriod?.period_number || null,
+              clockMs: event.clock_ms || 0,
+              sentiment: 0,
+              notes: event.notes,
+              createdAt: event.created_at,
+            }});
+          } catch {}
+        } catch (e) {
+          console.error('[LiveFormationService] formation_change event persist failed', e);
+        }
+
+        return { created, start, activeBefore };
+      });
+
+      // subs already prepared
+
+      // Broadcast SSE timeline event for formation change
+      try {
+        const { sseHub } = await import('../utils/sse');
+        // Determine current open period for context
+        const period = await this.prisma.match_periods.findFirst({
+          where: { match_id: matchId, is_deleted: false, ended_at: null },
+          orderBy: [{ started_at: 'desc' }]
+        });
+        sseHub.broadcast(matchId, 'formation_changed', {
+          matchId,
+          createdAt: new Date().toISOString(),
+          periodNumber: period?.period_number || null,
+          periodType: period?.period_type || 'REGULAR',
+          clockMs: Math.round(Number(result.start) * 60000),
+          reason: reason || null,
+          formation: formation,
+          prevFormation: (result.activeBefore?.formation_data as any) || null,
+          substitutions: subs,
+        });
+      } catch (e) {
+        // non-fatal
+      }
+
+      console.log('[LiveFormationService] applyFormationChange:done', { id: result.created.id });
+      return { liveFormationId: result.created.id, substitutions: subs };
+    }, 'LiveFormationChange');
+  }
+
+  async disconnect(): Promise<void> {
+    await this.prisma.$disconnect();
+    await this.lineupService.disconnect();
+    await this.positionCalc.disconnect();
+  }
+}

--- a/backend/src/utils/sse.ts
+++ b/backend/src/utils/sse.ts
@@ -83,6 +83,7 @@ export async function buildSnapshot(matchId: string) {
       period_number: true,
       clock_ms: true,
       sentiment: true,
+      notes: true,
       created_at: true,
     }
   });
@@ -150,6 +151,7 @@ export async function buildSnapshot(matchId: string) {
         periodType,
         clockMs: e.clock_ms ?? 0,
         sentiment: e.sentiment ?? 0,
+        notes: e.notes || null,
         createdAt: e.created_at?.toISOString?.() || null,
       });
     })

--- a/frontend/src/components/lineup/LineupManagementModal.tsx
+++ b/frontend/src/components/lineup/LineupManagementModal.tsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import { IonModal, IonHeader, IonToolbar, IonTitle, IonButtons, IonButton, IonContent, IonCard, IonCardContent, IonSelect, IonSelectOption, IonText, IonSpinner } from '@ionic/react';
+import { VisualPitchInterface, PlayerSelectionPanel, PlayerWithPosition, FormationData, PitchPosition } from './index';
+import formationsApi, { FormationDataDTO } from '../../services/api/formationsApi';
+import { defaultLineupsApi } from '../../services/api/defaultLineupsApi';
+import teamsApi from '../../services/api/teamsApi';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  matchId: string;
+  selectedTeamId: string;
+  currentMinute?: number;
+};
+
+const REASONS = ['Starting Lineup Adjustment', 'Playtime rotation', 'Injury', 'Formation Change', 'Power play', 'Power play x2'];
+
+const LineupManagementModal: React.FC<Props> = ({ isOpen, onClose, matchId, selectedTeamId, currentMinute = 0 }) => {
+  const [loading, setLoading] = useState(false);
+  const [roster, setRoster] = useState<PlayerWithPosition[]>([]);
+  const [formation, setFormation] = useState<FormationData>({ players: [] });
+  const [reason, setReason] = useState<string>('Playtime rotation');
+  const [applying, setApplying] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    (async () => {
+      setLoading(true);
+      try {
+        const [teamRes, curr] = await Promise.all([
+          selectedTeamId ? teamsApi.getTeamPlayers(selectedTeamId) : Promise.resolve({ data: [] }),
+          matchId ? formationsApi.getCurrent(matchId) : Promise.resolve(null)
+        ]);
+        const players: PlayerWithPosition[] = (teamRes?.data || []).map((p: any) => ({
+          id: p.id,
+          name: p.name,
+          squadNumber: p.squadNumber,
+          preferredPosition: p.preferredPosition,
+        }));
+        setRoster(players);
+        if (curr && Array.isArray(curr.players) && curr.players.length > 0) {
+          // Merge names from roster if missing
+          const mappedPlayers: PlayerWithPosition[] = curr.players.map((fp: any) => ({
+            id: fp.id,
+            name: fp.name || players.find(pp => pp.id === fp.id)?.name || 'Player',
+            squadNumber: fp.squadNumber ?? players.find(pp => pp.id === fp.id)?.squadNumber,
+            preferredPosition: fp.preferredPosition ?? players.find(pp => pp.id === fp.id)?.preferredPosition,
+            position: { x: fp.position?.x || 0, y: fp.position?.y || 0 }
+          }));
+          setFormation({ players: mappedPlayers });
+        } else {
+          // Fallback to default lineup for the selected team (pre‑kickoff case)
+          if (selectedTeamId) {
+            try {
+              const dl = await defaultLineupsApi.getDefaultLineup(selectedTeamId);
+              if (dl && Array.isArray(dl.formation)) {
+                const mapped: PlayerWithPosition[] = dl.formation.map(fp => ({
+                  id: fp.playerId,
+                  name: players.find(p => p.id === fp.playerId)?.name || 'Player',
+                  squadNumber: players.find(p => p.id === fp.playerId)?.squadNumber,
+                  preferredPosition: players.find(p => p.id === fp.playerId)?.preferredPosition,
+                  position: { x: fp.pitchX, y: fp.pitchY }
+                }));
+                setFormation({ players: mapped });
+              } else {
+                setFormation({ players: [] });
+              }
+            } catch {
+              setFormation({ players: [] });
+            }
+          } else {
+            setFormation({ players: [] });
+          }
+        }
+      } catch (e) {
+        console.warn('Failed to load formation/roster', e);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [isOpen, matchId, selectedTeamId]);
+
+  const onPlayerMove = useCallback((playerId: string, position: PitchPosition) => {
+    setFormation(prev => ({
+      players: prev.players.map(p => p.id === playerId ? { ...p, position } : p)
+    }));
+  }, []);
+
+  const onPlayerRemove = useCallback((playerId: string) => {
+    setFormation(prev => ({ players: prev.players.filter(p => p.id !== playerId) }));
+  }, []);
+
+  const addPlayerToFormation = useCallback((player: PlayerWithPosition) => {
+    setFormation(prev => {
+      if (prev.players.find(p => p.id === player.id)) return prev;
+      return { players: [...prev.players, { ...player, position: { x: 50, y: 50 } }] };
+    });
+  }, []);
+
+  const removePlayerFromPanel = useCallback((player: PlayerWithPosition) => {
+    setFormation(prev => ({ players: prev.players.filter(p => p.id !== player.id) }));
+  }, []);
+
+  const applyChanges = async () => {
+    try {
+      setApplying(true);
+      const dto: FormationDataDTO = {
+        players: formation.players.map(p => ({ id: p.id, name: p.name, squadNumber: p.squadNumber, preferredPosition: p.preferredPosition, position: { x: p.position?.x || 0, y: p.position?.y || 0 } }))
+      };
+      await formationsApi.applyChange(matchId, currentMinute || 0, dto, reason);
+      formationsApi.setCached(matchId, dto);
+      try { (window as any).__toastApi?.current?.showSuccess?.('Formation updated'); } catch {}
+      onClose();
+    } catch (e: any) {
+      console.error('Apply formation failed', e);
+      try { (window as any).__toastApi?.current?.showError?.(e?.message || 'Failed to apply changes'); } catch {}
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  return (
+    <IonModal isOpen={isOpen} onDidDismiss={onClose}>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Team Changes</IonTitle>
+          <IonButtons slot="end">
+            <IonButton onClick={onClose}>Close</IonButton>
+          </IonButtons>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent>
+        <div style={{ padding: 16, display: 'grid', gridTemplateColumns: '1fr', gap: 12 }}>
+          {loading ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <IonSpinner name="crescent" />
+              <IonText>Loading current formation…</IonText>
+            </div>
+          ) : (
+            <>
+              <IonCard>
+                <IonCardContent>
+                  <VisualPitchInterface
+                    players={roster}
+                    formation={formation}
+                    onPlayerMove={onPlayerMove}
+                    onPlayerRemove={onPlayerRemove}
+                    maxPlayers={11}
+                  />
+                </IonCardContent>
+              </IonCard>
+              <IonCard>
+                <IonCardContent>
+                  <PlayerSelectionPanel
+                    players={roster}
+                    onPlayerSelect={addPlayerToFormation}
+                    onPlayerRemove={removePlayerFromPanel}
+                    selectedPlayers={new Set(formation.players.map(p => p.id))}
+                  />
+                </IonCardContent>
+              </IonCard>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', padding: '0 8px 12px' }}>
+                <IonSelect interface="popover" value={reason} onIonChange={e => setReason(e.detail.value)} label="Reason" labelPlacement="stacked">
+                  {REASONS.map(r => (
+                    <IonSelectOption key={r} value={r}>{r}</IonSelectOption>
+                  ))}
+                </IonSelect>
+                <IonButton 
+                  color="primary" 
+                  fill="solid" 
+                  strong
+                  onClick={applyChanges} 
+                  style={{ marginLeft: 'auto' }}
+                  disabled={applying || !matchId || formation.players.length === 0}
+                >
+                  {applying ? 'Applying…' : 'Apply Changes'}
+                </IonButton>
+              </div>
+            </>
+          )}
+        </div>
+      </IonContent>
+    </IonModal>
+  );
+};
+
+export default LineupManagementModal;

--- a/frontend/src/components/lineup/VisualPitchInterface.css
+++ b/frontend/src/components/lineup/VisualPitchInterface.css
@@ -183,6 +183,18 @@
   stroke-width: 0.2;
 }
 
+/* Player short name label under circle */
+.player-label {
+  fill: #ffffff;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 1.8px;
+  font-weight: 600;
+  paint-order: stroke;
+  stroke: rgba(0,0,0,0.35);
+  stroke-width: 0.2;
+  pointer-events: none;
+}
+
 /* Player Count Indicator */
 .player-count {
   position: absolute;

--- a/frontend/src/components/live/LiveTimeline.css
+++ b/frontend/src/components/live/LiveTimeline.css
@@ -1,0 +1,21 @@
+.pitch-compact .visual-pitch-interface {
+  box-shadow: none;
+  border-radius: 6px;
+}
+
+.pitch-compact .pitch-container {
+  padding: 0;
+  min-height: 0;
+}
+
+.pitch-compact .football-pitch {
+  max-width: 100% !important;
+}
+
+/* Hide non-essential overlays in compact view */
+.pitch-compact .player-count,
+.pitch-compact .formation-indicator,
+.pitch-compact .position-feedback {
+  display: none !important;
+}
+

--- a/frontend/src/lib/formationCore.ts
+++ b/frontend/src/lib/formationCore.ts
@@ -66,31 +66,31 @@ export const ZONES: ZoneDef[] = [
   { code: 'RB',  area: { minX: 8,  maxX: 28, minY: 64, maxY: 100 }, priority: 2 },
   { code: 'LWB', area: { minX: 24, maxX: 42, minY: 0,  maxY: 32 }, priority: 2 },
   { code: 'RWB', area: { minX: 24, maxX: 42, minY: 68, maxY: 100 }, priority: 2 },
-  { code: 'WB',  area: { minX: 24, maxX: 42, minY: 20, maxY: 80 }, priority: 2 },
-  { code: 'FB',  area: { minX: 12, maxX: 32, minY: 20, maxY: 80 }, priority: 2 },
+  { code: 'WB',  area: { minX: 24, maxX: 42, minY: 20, maxY: 80 }, priority: 1 },
+  { code: 'FB',  area: { minX: 12, maxX: 32, minY: 20, maxY: 80 }, priority: 1 },
 
   // DM / CM / AM
   { code: 'CDM', area: { minX: 34, maxX: 52, minY: 30, maxY: 70 }, priority: 3 },
-  { code: 'DM',  area: { minX: 34, maxX: 52, minY: 30, maxY: 70 }, priority: 3 },
+  { code: 'DM',  area: { minX: 34, maxX: 52, minY: 30, maxY: 70 }, priority: 1 },
   { code: 'CM',  area: { minX: 54, maxX: 58, minY: 24, maxY: 76 }, priority: 3 },
-  { code: 'LCM', area: { minX: 50, maxX: 56, minY: 24, maxY: 50 }, priority: 3 },
-  { code: 'RCM', area: { minX: 50, maxX: 56, minY: 50, maxY: 76 }, priority: 3 },
+  { code: 'LCM', area: { minX: 50, maxX: 56, minY: 24, maxY: 50 }, priority: 1 },
+  { code: 'RCM', area: { minX: 50, maxX: 56, minY: 50, maxY: 76 }, priority: 1 },
   { code: 'CAM', area: { minX: 60, maxX: 66, minY: 30, maxY: 70 }, priority: 3 },
-  { code: 'LAM', area: { minX: 60, maxX: 68, minY:  8, maxY: 36 }, priority: 3 },
-  { code: 'RAM', area: { minX: 60, maxX: 68, minY: 64, maxY: 92 }, priority: 3 },
-  { code: 'AM',  area: { minX: 60, maxX: 68, minY: 24, maxY: 76 }, priority: 3 },
+  { code: 'LAM', area: { minX: 60, maxX: 68, minY:  8, maxY: 36 }, priority: 2 },
+  { code: 'RAM', area: { minX: 60, maxX: 68, minY: 64, maxY: 92 }, priority: 2 },
+  { code: 'AM',  area: { minX: 60, maxX: 68, minY: 24, maxY: 76 }, priority: 1 },
   { code: 'LM',  area: { minX: 40, maxX: 62, minY:  0, maxY: 30 }, priority: 3 },
   { code: 'RM',  area: { minX: 40, maxX: 62, minY: 70, maxY: 100 }, priority: 3 },
-  { code: 'WM',  area: { minX: 40, maxX: 62, minY: 20, maxY: 80 }, priority: 3 },
+  { code: 'WM',  area: { minX: 40, maxX: 62, minY: 20, maxY: 80 }, priority: 1 },
 
   // Forwards
   { code: 'LW',  area: { minX: 76, maxX: 98, minY:  0, maxY: 36 }, priority: 4 },
   { code: 'RW',  area: { minX: 76, maxX: 98, minY: 64, maxY: 100 }, priority: 4 },
   { code: 'CF',  area: { minX: 72, maxX: 96, minY: 30, maxY: 70 }, priority: 4 },
   { code: 'ST',  area: { minX: 82, maxX: 100,minY: 24, maxY: 76 }, priority: 4 },
-  { code: 'SS',  area: { minX: 70, maxX: 90, minY: 30, maxY: 70 }, priority: 4 },
-  { code: 'LF',  area: { minX: 80, maxX: 98, minY:  0, maxY: 40 }, priority: 4 },
-  { code: 'RF',  area: { minX: 80, maxX: 98, minY: 60, maxY: 100 }, priority: 4 },
+  { code: 'SS',  area: { minX: 70, maxX: 90, minY: 30, maxY: 70 }, priority: 2 },
+  { code: 'LF',  area: { minX: 80, maxX: 98, minY:  0, maxY: 40 }, priority: 2 },
+  { code: 'RF',  area: { minX: 80, maxX: 98, minY: 60, maxY: 100 }, priority: 2 },
 ];
 
 // ===== Utilities =====

--- a/frontend/src/pages/LineupManagementPage.css
+++ b/frontend/src/pages/LineupManagementPage.css
@@ -287,7 +287,7 @@
 }
 
 /* Save Button States */
-ion-button[disabled] {
+.lineup-management-content ion-button[disabled] {
   opacity: 0.5;
 }
 

--- a/frontend/src/services/api/formationsApi.ts
+++ b/frontend/src/services/api/formationsApi.ts
@@ -1,0 +1,56 @@
+import apiClient from './baseApi';
+
+export interface FormationPlayerDTO {
+  id: string;
+  name: string;
+  squadNumber?: number;
+  preferredPosition?: string;
+  position: { x: number; y: number };
+}
+
+export interface FormationDataDTO { players: FormationPlayerDTO[] }
+
+// Simple in-memory cache keyed by matchId
+const formationCache = new Map<string, FormationDataDTO>();
+const inflight = new Map<string, Promise<FormationDataDTO | null>>();
+
+export const formationsApi = {
+  async getCurrent(matchId: string, opts: { useCache?: boolean } = { useCache: true }): Promise<FormationDataDTO | null> {
+    const { useCache = true } = opts;
+    if (useCache && formationCache.has(matchId)) return formationCache.get(matchId)!;
+    if (inflight.has(matchId)) return inflight.get(matchId)!;
+    const p = (async () => {
+      try {
+        const resp = await apiClient.get<FormationDataDTO>(`/matches/${matchId}/current-formation`);
+        const data = (resp.data as any) || null;
+        if (data) formationCache.set(matchId, data);
+        return data;
+      } finally {
+        inflight.delete(matchId);
+      }
+    })();
+    inflight.set(matchId, p);
+    return p;
+  },
+
+  async prefetch(matchId: string): Promise<void> {
+    try { await this.getCurrent(matchId, { useCache: true }); } catch {}
+  },
+
+  setCached(matchId: string, data: FormationDataDTO) {
+    formationCache.set(matchId, data);
+  },
+
+  invalidate(matchId: string) {
+    formationCache.delete(matchId);
+  },
+
+  async applyChange(matchId: string, startMin: number, formation: FormationDataDTO, reason?: string) {
+    const resp = await apiClient.post(`/matches/${matchId}/formation-changes`, { startMin, formation, reason });
+    // Optimistically update cache with the new formation
+    formationCache.set(matchId, formation);
+    return resp.data as any;
+  }
+};
+
+export default formationsApi;

--- a/shared/types/prisma.ts
+++ b/shared/types/prisma.ts
@@ -33,7 +33,7 @@ export type PrismaPosition = {
 import type { Prisma } from '@prisma/client';
 
 // Export enum type
-export type EventKind = 'goal' | 'assist' | 'key_pass' | 'save' | 'interception' | 'tackle' | 'foul' | 'penalty' | 'free_kick' | 'ball_out' | 'own_goal';
+export type EventKind = 'goal' | 'assist' | 'key_pass' | 'save' | 'interception' | 'tackle' | 'foul' | 'penalty' | 'free_kick' | 'ball_out' | 'own_goal' | 'formation_change';
 
 // Create our own input types since Event model is ignored
 export type PrismaPlayerCreateInput = {


### PR DESCRIPTION
add formation changes to live matches by leveraging existing default lineup pitch interface
new live_formation table keeps entire json history and coach can move players around the pitch during the match
"lineup" table still exists and is updated after every change as the lineup table will help with statistics calculations way more than database json
Update all position defaults etc in DB to ensure that the system picks the correct position to assign when saving the layout so that the lineup table is correct for analysis purposes
add formation changes to timeline as a pitch interface read-only view for cool visuals during subs 