### PR TITLE
feat: update SyncService to use local tables correctly instead of outbox

### DIFF
--- a/.kiro/specs/authenticated-offline-mode/design.md
+++ b/.kiro/specs/authenticated-offline-mode/design.md
@@ -1,0 +1,339 @@
+# Design Document: Authenticated Offline Mode
+
+## Overview
+
+This design implements local-first architecture for authenticated users, allowing them to continue working when offline or with poor connectivity. The approach mirrors the existing guest mode pattern: write to local IndexedDB tables with `synced: false`, then sync to server when online.
+
+The key insight is that the infrastructure already exists from the offline-sync-refactor spec - we just need to add offline fallbacks to the API services.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph "API Service Layer"
+        EA[Events API]
+        MA[Matches API]
+        TA[Teams API]
+        PA[Players API]
+    end
+    
+    subgraph "Network Detection"
+        ND[isOnline Check]
+        NE[Network Events]
+    end
+    
+    subgraph "Local Storage"
+        ET[events table]
+        MT[matches table]
+        MP[match_periods table]
+        MS[match_state table]
+        TT[teams table]
+        PT[players table]
+    end
+    
+    subgraph "Sync Layer"
+        SS[Sync Service]
+    end
+    
+    subgraph "Server"
+        API[REST API]
+    end
+    
+    EA --> ND
+    MA --> ND
+    TA --> ND
+    PA --> ND
+    
+    ND -->|Online| API
+    ND -->|Offline| ET
+    ND -->|Offline| MT
+    ND -->|Offline| MP
+    ND -->|Offline| MS
+    ND -->|Offline| TT
+    ND -->|Offline| PT
+    
+    NE --> SS
+    SS --> ET
+    SS --> MT
+    SS --> MP
+    SS --> MS
+    SS --> TT
+    SS --> PT
+    SS --> API
+```
+
+### Data Flow
+
+**Online Mode (Current Behavior):**
+```
+User Action → API Service → Server API → Response → UI Update
+```
+
+**Offline Mode (New Behavior):**
+```
+User Action → API Service → Network Check → Offline Detected
+    → Write to Local Table (synced: false)
+    → Return Local Data → UI Update
+    
+Later: Online Event → Sync Service → Server API → Update synced: true
+```
+
+## Components and Interfaces
+
+### Network Detection Utility
+
+**File:** `frontend/src/utils/network.ts`
+
+```typescript
+/**
+ * Check if the device is currently online
+ */
+export function isOnline(): boolean {
+  return typeof navigator !== 'undefined' && navigator.onLine;
+}
+
+/**
+ * Check if a request should use offline fallback
+ * Returns true if offline OR if the error is a network error
+ */
+export function shouldUseOfflineFallback(error?: Error): boolean {
+  if (!isOnline()) return true;
+  if (error?.message?.includes('Network') || 
+      error?.message?.includes('fetch') ||
+      error?.name === 'TypeError') {
+    return true;
+  }
+  return false;
+}
+```
+
+### API Service Pattern
+
+Each API service will follow this pattern for write operations:
+
+```typescript
+async function createEntity(data: EntityData): Promise<Entity> {
+  // Try server first if online
+  if (isOnline()) {
+    try {
+      const response = await apiClient.post('/entities', data);
+      return response.data;
+    } catch (error) {
+      // If network error, fall through to offline handling
+      if (!shouldUseOfflineFallback(error)) {
+        throw error; // Re-throw non-network errors (400, 401, etc.)
+      }
+    }
+  }
+  
+  // Offline fallback: write to local table
+  const localEntity = await writeToLocalTable(data);
+  showOfflineToast('Saved locally - will sync when online');
+  return localEntity;
+}
+```
+
+### Events API Updates
+
+**File:** `frontend/src/services/api/eventsApi.ts`
+
+```typescript
+async create(event: EventCreateRequest): Promise<Event> {
+  // Try server first if online
+  if (isOnline()) {
+    try {
+      const response = await apiClient.post<Event>('/events', event);
+      return response.data;
+    } catch (error) {
+      if (!shouldUseOfflineFallback(error)) throw error;
+    }
+  }
+  
+  // Offline fallback
+  const { db } = await import('../../db/indexedDB');
+  const { getAuthUserId } = await import('../../utils/auth');
+  
+  const localEvent = {
+    id: `event-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+    match_id: event.matchId,
+    kind: event.kind,
+    period_number: event.periodNumber,
+    clock_ms: event.clockMs,
+    team_id: event.teamId,
+    player_id: event.playerId,
+    notes: event.notes,
+    sentiment: event.sentiment || 0,
+    ts_server: Date.now(),
+    created_at: Date.now(),
+    updated_at: Date.now(),
+    created_by_user_id: getAuthUserId(), // Use authenticated user ID
+    is_deleted: false,
+    synced: false,
+  };
+  
+  await db.events.add(localEvent);
+  showOfflineToast('Event saved locally');
+  
+  return transformToApiEvent(localEvent);
+}
+```
+
+### Matches API Updates
+
+**File:** `frontend/src/services/api/matchesApi.ts`
+
+Key methods needing offline fallback:
+- `startMatch()` - Create match_state with status LIVE
+- `pauseMatch()` - Update match_state to PAUSED
+- `resumeMatch()` - Update match_state to LIVE
+- `completeMatch()` - Update match_state to COMPLETED
+- `startPeriod()` - Create match_periods record
+- `endPeriod()` - Update match_periods with ended_at
+
+### Teams API Updates
+
+**File:** `frontend/src/services/api/teamsApi.ts`
+
+```typescript
+async createTeam(teamData: TeamCreateRequest): Promise<Team> {
+  if (isOnline()) {
+    try {
+      const response = await apiClient.post<Team>('/teams', teamData);
+      return response.data;
+    } catch (error) {
+      if (!shouldUseOfflineFallback(error)) throw error;
+    }
+  }
+  
+  // Offline fallback - similar to guest mode but with auth user ID
+  const { db } = await import('../../db/indexedDB');
+  const { getAuthUserId } = await import('../../utils/auth');
+  
+  const id = crypto.randomUUID();
+  await db.teams.add({
+    id,
+    team_id: id,
+    name: teamData.name,
+    color_primary: teamData.homeKitPrimary,
+    color_secondary: teamData.homeKitSecondary,
+    created_at: Date.now(),
+    updated_at: Date.now(),
+    created_by_user_id: getAuthUserId(),
+    is_deleted: false,
+    synced: false,
+  });
+  
+  return transformToApiTeam(await db.teams.get(id));
+}
+```
+
+### Offline Status Indicator
+
+**File:** `frontend/src/components/OfflineIndicator.tsx`
+
+```typescript
+export function OfflineIndicator() {
+  const [isOffline, setIsOffline] = useState(!navigator.onLine);
+  const [pendingSync, setPendingSync] = useState(0);
+  
+  useEffect(() => {
+    const handleOnline = () => setIsOffline(false);
+    const handleOffline = () => setIsOffline(true);
+    
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+  
+  if (!isOffline && pendingSync === 0) return null;
+  
+  return (
+    <div className="offline-indicator">
+      {isOffline ? (
+        <span>📴 Offline - changes saved locally</span>
+      ) : (
+        <span>🔄 Syncing {pendingSync} items...</span>
+      )}
+    </div>
+  );
+}
+```
+
+## Data Models
+
+No new data models required. Uses existing tables with `synced` flag:
+- `events` table
+- `matches` table
+- `match_periods` table
+- `match_state` table
+- `teams` table
+- `players` table
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system-essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Offline Event Creation
+
+*For any* event creation request while offline, the event should be stored in the local events table with `synced` equals false and `created_by_user_id` equals the authenticated user's ID.
+
+**Validates: Requirements 1.1, 5.1**
+
+### Property 2: Offline Data Persistence
+
+*For any* data created while offline, the data should persist in local storage and be available for reading even after app restart.
+
+**Validates: Requirements 1.2, 2.1, 3.1, 3.2**
+
+### Property 3: Automatic Sync on Reconnect
+
+*For any* unsynced record created by an authenticated user, when the device comes back online, the Sync Service should attempt to sync that record to the server.
+
+**Validates: Requirements 1.3, 2.4, 3.3**
+
+### Property 4: Network Error Fallback
+
+*For any* API call that fails with a network error, the system should fall back to local storage instead of throwing an error to the user.
+
+**Validates: Requirements 6.1, 6.2**
+
+### Property 5: User Attribution Preservation
+
+*For any* data created offline by an authenticated user, the `created_by_user_id` should be the authenticated user's ID (not a guest ID), and this should be preserved when synced to the server.
+
+**Validates: Requirements 5.1, 5.2, 5.3**
+
+## Error Handling
+
+| Error Condition | Handling Strategy |
+|----------------|-------------------|
+| Network offline | Write to local table, show offline indicator |
+| API timeout | Treat as offline, write locally |
+| API 5xx error | Treat as offline, write locally, retry later |
+| API 4xx error | Do NOT fall back to local (validation error) |
+| Local storage full | Show error, suggest clearing old data |
+| Sync conflict | Server wins for same record, preserve local unsynced |
+
+## Testing Strategy
+
+### Unit Tests
+- Test each API service's offline fallback behavior
+- Test network detection utility
+- Test offline indicator component
+
+### Property-Based Tests
+- Property 1: Offline event creation
+- Property 2: Offline data persistence
+- Property 3: Automatic sync on reconnect
+- Property 4: Network error fallback
+- Property 5: User attribution preservation
+
+### Integration Tests
+- Full offline/online cycle test
+- Intermittent connectivity test
+- Multiple offline operations then sync test
+

--- a/.kiro/specs/authenticated-offline-mode/requirements.md
+++ b/.kiro/specs/authenticated-offline-mode/requirements.md
@@ -1,0 +1,85 @@
+# Requirements Document
+
+## Introduction
+
+This specification addresses the gap where authenticated users lose network connectivity (offline or bad signal) while using the application. Currently, the app assumes authenticated users are always online, causing API calls to fail without local fallbacks. This spec implements a "local-first" architecture for authenticated users, allowing them to continue working offline with automatic sync when connectivity is restored.
+
+The architecture follows the same pattern as guest mode: write to local IndexedDB tables with `synced: false`, then sync to server when online. The key difference is that authenticated users have a user ID instead of a guest ID.
+
+## Glossary
+
+- **Authenticated User**: A user who has logged in with valid credentials
+- **Offline Mode**: State where the device has no network connectivity or poor signal
+- **Local-First**: Architecture where data is written locally first, then synced to server
+- **Synced Flag**: Boolean field indicating whether a record has been synchronized to the server
+- **Network Detection**: Mechanism to detect online/offline state using `navigator.onLine` and network events
+
+## Requirements
+
+### Requirement 1
+
+**User Story:** As an authenticated user with poor connectivity, I want to create events during a live match, so that I don't lose important match data due to network issues.
+
+#### Acceptance Criteria
+
+1. WHEN an authenticated user creates an event while offline THEN the Events_API SHALL write the event to the local events table with synced equals false
+2. WHEN an authenticated user creates an event while offline THEN the Events_API SHALL return the locally created event without throwing a network error
+3. WHEN the device comes back online THEN the Sync_Service SHALL automatically sync the locally created events to the server
+4. WHEN the event is successfully synced THEN the Sync_Service SHALL update the local record with synced equals true and synced_at timestamp
+
+### Requirement 2
+
+**User Story:** As an authenticated user with poor connectivity, I want to manage match state (start, pause, resume, complete), so that I can track match progress even without network.
+
+#### Acceptance Criteria
+
+1. WHEN an authenticated user starts a match while offline THEN the Matches_API SHALL create local match_state and match_periods records with synced equals false
+2. WHEN an authenticated user pauses or resumes a match while offline THEN the Matches_API SHALL update local match_state with synced equals false
+3. WHEN an authenticated user completes a match while offline THEN the Matches_API SHALL update local match_state to COMPLETED with synced equals false
+4. WHEN the device comes back online THEN the Sync_Service SHALL sync match state changes in chronological order
+
+### Requirement 3
+
+**User Story:** As an authenticated user, I want to create teams, players, seasons, and matches while offline, so that I can set up and manage matches even without network connectivity.
+
+#### Acceptance Criteria
+
+1. WHEN an authenticated user creates a team while offline THEN the Teams_API SHALL write the team to the local teams table with synced equals false
+2. WHEN an authenticated user creates a player while offline THEN the Players_API SHALL write the player to the local players table with synced equals false
+3. WHEN an authenticated user creates a season while offline THEN the Seasons_API SHALL write the season to the local seasons table with synced equals false
+4. WHEN an authenticated user creates a match while offline THEN the Matches_API SHALL write the match to the local matches table with synced equals false
+5. WHEN the device comes back online THEN the Sync_Service SHALL sync tables in dependency order: seasons, teams, players, matches, lineups, events
+6. WHEN a record is successfully synced THEN the local record SHALL be updated with synced equals true and synced_at timestamp
+
+### Requirement 4
+
+**User Story:** As an authenticated user, I want clear feedback about my connectivity status, so that I understand when my data is being saved locally vs synced to the server.
+
+#### Acceptance Criteria
+
+1. WHEN the device goes offline THEN the System SHALL display a visual indicator showing offline status
+2. WHEN data is saved locally while offline THEN the System SHALL show a toast notification indicating local save
+3. WHEN the device comes back online THEN the System SHALL show sync progress indicator
+4. WHEN sync completes THEN the System SHALL show confirmation that data has been synced
+
+### Requirement 5
+
+**User Story:** As an authenticated user, I want my offline-created data to be properly attributed to my account, so that it appears correctly when synced.
+
+#### Acceptance Criteria
+
+1. WHEN an authenticated user creates data while offline THEN the record SHALL have created_by_user_id set to the authenticated user's ID (not a guest ID)
+2. WHEN offline data is synced THEN the server SHALL associate the data with the authenticated user's account
+3. WHEN viewing data after sync THEN the user SHALL see their offline-created data alongside server data
+
+### Requirement 6
+
+**User Story:** As an authenticated user, I want the app to gracefully handle intermittent connectivity, so that I don't lose data during brief network interruptions.
+
+#### Acceptance Criteria
+
+1. WHEN an API call fails due to network error THEN the System SHALL automatically fall back to local storage
+2. WHEN network connectivity is intermittent THEN the System SHALL queue failed operations for retry
+3. WHEN the Sync_Service retries a failed operation THEN it SHALL use exponential backoff to avoid overwhelming the server
+4. WHEN a sync operation fails repeatedly THEN the System SHALL preserve the local data and notify the user
+

--- a/.kiro/specs/authenticated-offline-mode/tasks.md
+++ b/.kiro/specs/authenticated-offline-mode/tasks.md
@@ -1,0 +1,174 @@
+# Implementation Plan
+
+## Note on Sync Service Gap
+
+The current sync service (from offline-sync-refactor) only syncs:
+- events
+- match_periods  
+- match_state
+
+But these tables also have `synced` flags and need sync support:
+- teams
+- players
+- seasons
+- matches
+- lineup
+- default_lineups
+
+This spec will add sync support for all tables.
+
+---
+
+- [x] 1. Network Detection Utilities
+  - [x] 1.1 Create network utility module
+    - Create `frontend/src/utils/network.ts`
+    - Implement `isOnline()` function using `navigator.onLine`
+    - Implement `shouldUseOfflineFallback(error)` to detect network errors
+    - _Requirements: 6.1_
+  - [x] 1.2 Create auth user ID utility
+    - Add `getAuthUserId()` function to get current authenticated user's ID
+    - Return user ID from auth context/token
+    - _Requirements: 5.1_
+
+- [ ] 2. Events API Offline Fallback
+  - [ ] 2.1 Add offline fallback to eventsApi.create()
+    - Check `isOnline()` before API call
+    - On network error, write to local events table with `synced: false`
+    - Use authenticated user ID for `created_by_user_id`
+    - Return transformed local event
+    - _Requirements: 1.1, 1.2, 5.1_
+  - [ ] 2.2 Add offline fallback to eventsApi.update()
+    - Similar pattern to create
+    - Update local record if exists
+    - _Requirements: 1.1_
+  - [ ] 2.3 Add offline fallback to eventsApi.delete()
+    - Mark local record as deleted
+    - _Requirements: 1.1_
+
+- [ ] 3. Matches API Offline Fallback
+  - [ ] 3.1 Add offline fallback to matchesApi.startMatch()
+    - Create local match_state with status LIVE
+    - Create first match_period record
+    - _Requirements: 2.1_
+  - [ ] 3.2 Add offline fallback to matchesApi.pauseMatch()
+    - Update local match_state to PAUSED
+    - _Requirements: 2.2_
+  - [ ] 3.3 Add offline fallback to matchesApi.resumeMatch()
+    - Update local match_state to LIVE
+    - _Requirements: 2.2_
+  - [ ] 3.4 Add offline fallback to matchesApi.completeMatch()
+    - Update local match_state to COMPLETED
+    - End any open periods
+    - _Requirements: 2.3_
+  - [ ] 3.5 Add offline fallback to matchesApi.startPeriod()
+    - Create local match_periods record
+    - _Requirements: 2.1_
+  - [ ] 3.6 Add offline fallback to matchesApi.endPeriod()
+    - Update local match_periods with ended_at
+    - _Requirements: 2.1_
+
+- [ ] 4. Teams API Offline Fallback
+  - [ ] 4.1 Add offline fallback to teamsApi.createTeam()
+    - Write to local teams table with `synced: false`
+    - Use authenticated user ID
+    - _Requirements: 3.1, 5.1_
+  - [ ] 4.2 Add offline fallback to teamsApi.updateTeam()
+    - Update local record
+    - _Requirements: 3.1_
+
+- [ ] 5. Players API Offline Fallback
+  - [ ] 5.1 Add offline fallback to playersApi.createPlayer()
+    - Write to local players table with `synced: false`
+    - Use authenticated user ID
+    - _Requirements: 3.2, 5.1_
+  - [ ] 5.2 Add offline fallback to playersApi.updatePlayer()
+    - Update local record
+    - _Requirements: 3.2_
+
+- [ ] 6. Checkpoint - Verify API Fallbacks
+  - Ensure all API services have offline fallbacks
+  - Test each API in offline mode
+
+- [ ] 7. Sync Service - Add Missing Table Sync Functions
+  - [ ] 7.1 Add syncTeams() function
+    - Query teams table where `synced` equals false
+    - Exclude guest records
+    - POST to teams API endpoint
+    - Update `synced` to true on success
+    - _Requirements: 3.1, 3.3_
+  - [ ] 7.2 Add syncPlayers() function
+    - Query players table where `synced` equals false
+    - Exclude guest records
+    - POST to players API endpoint
+    - Update `synced` to true on success
+    - _Requirements: 3.2, 3.3_
+  - [ ] 7.3 Add syncSeasons() function
+    - Query seasons table where `synced` equals false
+    - Exclude guest records
+    - POST to seasons API endpoint
+    - Update `synced` to true on success
+    - _Requirements: 3.3_
+  - [ ] 7.4 Add syncMatches() function
+    - Query matches table where `synced` equals false
+    - Exclude guest records
+    - POST to matches API endpoint
+    - Update `synced` to true on success
+    - _Requirements: 3.3_
+  - [ ] 7.5 Add syncLineups() function
+    - Query lineup table where `synced` equals false
+    - Exclude guest records
+    - POST to lineups API endpoint
+    - Update `synced` to true on success
+    - _Requirements: 3.3_
+  - [ ] 7.6 Add syncDefaultLineups() function
+    - Query default_lineups table where `synced` equals false
+    - Exclude guest records
+    - POST to default-lineups API endpoint
+    - Update `synced` to true on success
+    - _Requirements: 3.3_
+  - [ ] 7.7 Update flushOnce() with correct sync order
+    - Sync in order: seasons → teams → players → matches → lineups → default_lineups → events → match_periods → match_state
+    - This ensures referential integrity (parent records synced before children)
+    - _Requirements: 3.3, 3.4_
+  - [ ] 7.8 Add sync progress tracking
+    - Track number of pending items per table
+    - Emit events for UI to display progress
+    - _Requirements: 4.3_
+
+- [ ] 8. Offline Status UI
+  - [ ] 8.1 Create OfflineIndicator component
+    - Show offline status when `navigator.onLine` is false
+    - Show sync progress when coming back online
+    - _Requirements: 4.1, 4.3_
+  - [ ] 8.2 Add offline toast notifications
+    - Show toast when data is saved locally
+    - Show toast when sync completes
+    - _Requirements: 4.2, 4.4_
+  - [ ] 8.3 Integrate OfflineIndicator into app layout
+    - Add to main app layout
+    - Position appropriately for mobile/desktop
+    - _Requirements: 4.1_
+
+- [ ] 9. Checkpoint - Verify Offline UI
+  - Test offline indicator visibility
+  - Test toast notifications
+
+- [ ] 10. Error Handling and Retry Logic
+  - [ ] 10.1 Implement exponential backoff for sync retries
+    - Start with 1 second delay
+    - Double delay on each retry up to max 5 minutes
+    - _Requirements: 6.3_
+  - [ ] 10.2 Add max retry limit with user notification
+    - After 5 failed retries, notify user
+    - Preserve local data
+    - _Requirements: 6.4_
+  - [ ] 10.3 Distinguish network errors from validation errors
+    - Only fall back to local for network errors
+    - Show validation errors to user immediately
+    - _Requirements: 6.1_
+
+- [ ] 11. Final Checkpoint - Full Integration Test
+  - Test complete offline/online cycle
+  - Test intermittent connectivity
+  - Verify data integrity after sync
+

--- a/.kiro/specs/offline-sync-refactor/tasks.md
+++ b/.kiro/specs/offline-sync-refactor/tasks.md
@@ -42,24 +42,24 @@
     - Test network failure handling
     - _Requirements: 1.6_
 
-- [ ] 3. Checkpoint - Verify Import Flow
+- [x] 3. Checkpoint - Verify Import Flow
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 4. Sync Service Updates (Milestone 5)
-  - [ ] 4.1 Implement table-based sync for events
+- [x] 4. Sync Service Updates (Milestone 5)
+  - [x] 4.1 Implement table-based sync for events
     - Query events table where `synced` equals false
     - Exclude records where `created_by_user_id` starts with 'guest-'
     - POST to events API endpoint
     - Update `synced` to true and set `synced_at` on success
     - Batch operations (50 records per batch)
     - _Requirements: 2.1, 2.4, 2.6_
-  - [ ] 4.2 Implement table-based sync for match periods
+  - [x] 4.2 Implement table-based sync for match periods
     - Query match_periods table where `synced` equals false
     - Exclude guest records
     - Use appropriate API based on period completion status
     - Update sync flags on success
     - _Requirements: 2.2, 2.4, 2.6_
-  - [ ] 4.3 Implement table-based sync for match state
+  - [x] 4.3 Implement table-based sync for match state
     - Query match_state table where `synced` equals false
     - Exclude guest records
     - Sync state changes to server
@@ -74,7 +74,8 @@
   - [ ]* 4.6 Write property test for guest data sync exclusion
     - **Property 6: Guest Data Sync Exclusion**
     - **Validates: Requirements 2.6**
-  - [ ] 4.7 Remove outbox-based sync code
+  - [x] 4.7 Remove outbox-based sync code
+
     - Remove outbox processing from flushOnce()
     - Keep outbox table for migration period
     - _Requirements: 5.2_


### PR DESCRIPTION
Problem with requirements you don't read too carefully... it only did match_state, match_period and events. 
Also realised that authenticated users will always try and call API and if that fails there is no local fallback at all... even though the guest mode works perfectly fine. So we created a new requirement for authenticated offline. 